### PR TITLE
宿の編集ページ作成

### DIFF
--- a/app/assets/stylesheets/lodging/show.scss
+++ b/app/assets/stylesheets/lodging/show.scss
@@ -29,6 +29,8 @@ body {
 
 .center {
   width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .center-image {
@@ -45,14 +47,12 @@ body {
 
 .under {
   width: 100%;
-}
-
-.under {
-  display: flex;
+  display: block;
 }
 
 .under-child1 {
-  padding-left: 100px;
+  padding: 0 200px;
+  flex-grow: 1;
 }
 
 .child1-title {
@@ -64,7 +64,7 @@ body {
 .under-child2 {
   flex-grow: 1;
   padding: 0 200px;
-  margin-top: 30px;
+  margin-top: 100px;
 }
 
 #map {
@@ -77,5 +77,3 @@ footer {
   display: flex;
   justify-content: center;
 }
-
-

--- a/app/controllers/lodgings_controller.rb
+++ b/app/controllers/lodgings_controller.rb
@@ -28,10 +28,10 @@ class LodgingsController < ApplicationController
   end
 
   def update
-    lodge = Lodging.find(lodge_params)
+    lodge = Lodging.find(params[:id])
     if lodge.valid?
       lodge.update(lodge_params)
-      redirect_to root_path
+      redirect_to lodging_path(lodge.id)
     else
       render :edit
     end

--- a/app/views/lodgings/edit.html.erb
+++ b/app/views/lodgings/edit.html.erb
@@ -1,0 +1,84 @@
+<%# CSSは、宿登録ページの物を使用 %>
+<%= render "shared/header" %>
+
+<div class="lodge-addmain">
+  <%= form_with model: @lodge, local: true do |f| %>
+    <div class="lodge-address">
+      <div class="lodge-description">
+        <div class="message1">宿を登録</div>
+        <div class="message2">予約されるまでは、詳細な情報は公開されません。</div>
+      </div>
+
+      <div class="name-price">
+        <div class="form-group">
+          <label for="namelabel">
+          宿の名前は？
+          <span class="indispensable">必須</span>
+          </label>
+        </div>
+        <%= f.text_field :lodge_name, class:'lodge-text', id:'namelabel', placeholder:'例) ライダーハウス'%>
+
+        <div class="form-group price-box">
+          <label for="pricelabel">
+          1泊の値段は？
+          <span class="indispensable">必須</span>
+          </label>
+        </div>
+        <%= f.text_field :price, class:'lodge-text', id:'pricelabel', placeholder:'例) 3000'%>
+      </div>
+
+      <div class="form-group">
+        <label for="postlabel">
+        郵便番号
+        <span class="indispensable">必須</span>
+        </label>
+      </div>
+      <%= f.text_field :postcode, class:'lodge-text', id:'postlabel', placeholder:'例) 102-3456' %>
+
+      <div class="form-group">
+        <label for="pref-city">
+        都道府県&市区町村
+        <span class="indispensable">必須</span>
+        </label>
+      </div>
+      <%= f.text_field :prefecture_city, class:'lodge-text', id:'pref-city', placeholder: '例)東京都新宿区' %>
+
+      <div class="form-group">
+        <label for="blocklabel">
+        番地
+        <span class="indispensable">必須</span>
+        </label>
+      </div>
+      <%= f.text_field :block_number, class:'lodge-text', id:'blocklabel', placeholder:'例) 新宿1-1-1' %>
+          
+      <div class="form-group">
+        <label for="buildinglabel">
+        建物名
+        </label>
+      </div>
+      <%= f.text_field :building, class:'lodge-text', id:'buildinglabel', placeholder:'例) 新宿ビル'%>
+
+      <div class="form-group">
+        <label for="lodge-desc">
+        この宿について
+        <span class="indispensable">必須</span>
+        </label>
+      </div>
+      <%= f.text_area :description, class:"lodge-text", id:"lodge-desc", placeholder:"宿の説明", rows:"7" ,maxlength:"1000" %>
+
+
+      <%= f.file_field :images, name: 'lodging[images][]', id: 'lodging_image' %>
+      <div id="edit-image">
+        <% @lodge.images.each do |image| %>
+          <%= image_tag image, class: 'images' %>
+        <% end %>  
+      </div>
+
+
+      <div class="btn">
+        <%= f.submit '内容を更新する', class:'provide-btn' %>
+      </div>
+      <%= link_to '戻る', lodging_path(@lodge.id), class:'back-btn' %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
#What
宿の情報を編集するための、編集ページを作成。

#Why
常に最新の情報を閲覧できるように編集ページの実装を行った。
ルーティングでは編集に成功すると、リダイレクト先として、更新した宿詳細ページに遷移するように、設定。
更新に失敗すると、編集ページに止まるようにルーティングを設定。