### PR TITLE
migrationファイルの編集

### DIFF
--- a/db/migrate/20200908100442_create_lodgings.rb
+++ b/db/migrate/20200908100442_create_lodgings.rb
@@ -11,8 +11,5 @@ class CreateLodgings < ActiveRecord::Migration[6.0]
       t.integer         :host_user_id,   foreign_key: true
       t.timestamps
     end
-
-    add_column :lodgings, :latitude, :float
-    add_column :lodgings, :longitude, :float
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,6 @@ ActiveRecord::Schema.define(version: 2020_09_10_130223) do
     t.integer "host_user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.float "latitude"
-    t.float "longitude"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
# What
lodgingモデルのlatitude/longitudeカラムを削除。

# Why
gem geocoder使用時に記述していた経度緯度情報を格納するカラムは、
googleのgeocoding APIを使用して、不要になったので、今回は削除しました。