### PR TITLE
宿情報に関するparamsの修正

### DIFF
--- a/app/controllers/lodgings_controller.rb
+++ b/app/controllers/lodgings_controller.rb
@@ -51,7 +51,7 @@ class LodgingsController < ApplicationController
   private
 
   def lodge_params
-    params.require(:lodging).permit(:lodge_name, :price, :postcode, :prefecture_city, :latitude, :longitude, :block_number, :building, :description, images: []).merge(host_user_id: current_host_user.id)
+    params.require(:lodging).permit(:lodge_name, :price, :postcode, :prefecture_city, :block_number, :building, :description, images: []).merge(host_user_id: current_host_user.id)
 
   end
 


### PR DESCRIPTION
# What
migrationファイルの編集による、params情報の編集。

# Why
migrationファイルに渡す情報には、経度緯度情報は不要になったため
それらの情報を渡さないために、paramsのlatitude/longitudeのキーを削除しました。