### PR TITLE
overflow: hiddenでboxに収める

### DIFF
--- a/app/assets/stylesheets/lodging/index.scss
+++ b/app/assets/stylesheets/lodging/index.scss
@@ -89,3 +89,8 @@ li {
   text-align: center;
   font-size: 18px;
 }
+
+#wrapper {
+  width:100%;
+  overflow:hidden;
+}

--- a/app/controllers/lodgings_controller.rb
+++ b/app/controllers/lodgings_controller.rb
@@ -20,7 +20,6 @@ class LodgingsController < ApplicationController
   end
 
   def show
-    gon.lodge = @lodge
   end
 
   def edit

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,9 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div id="wrapper">
+      <%= yield %>
+    </div>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>


### PR DESCRIPTION
#What
overflow: hidden;とすることで、画面の右側の余白をなくす。
全てに適応できるように、application.hrml.erbのyieldをdivで囲み
idを指定して、適応。

# Why
画面が右にスクロールできるようになってしまっていた為overflow: hidden;
としました。